### PR TITLE
0.6.7 - Super Primitives update, stack()

### DIFF
--- a/src/core/position.js
+++ b/src/core/position.js
@@ -6,6 +6,11 @@
  */
 
 const positionUtils = ({ lib }) => {
+    const {
+        measureDimensions,
+        measureBoundingBox,
+    } = lib.measurements
+
     /**
      * Measures key info, and presents it in a readable manner, like `{ size: { x: 99, y: 99, z: 99 }, min: { ... }, max: { ... } }`
      * @memberof core.position
@@ -13,19 +18,28 @@ const positionUtils = ({ lib }) => {
      * @returns ...
      */
     const measure = (inputGeom) => {
-        const {
-            measureDimensions,
-            measureBoundingBox,
-        } = lib.measurements
-
         return {
             boundingBox: measureBoundingBox(inputGeom),
             dimensions: measureDimensions(inputGeom),
         }
     };
 
+    const getGeomCoords = (geom) => {
+        const bBox = measureBoundingBox(geom);
+
+        return {
+            right: bBox[1][0], // (+X)
+            left: bBox[0][0], // (-X)
+            back: bBox[1][1], // (+Y)
+            front: bBox[0][1], // (-Y)
+            top: bBox[1][2], // (+Z)
+            bottom: bBox[0][2], // (-Z)
+        }
+    }
+
     return {
         measure,
+        getGeomCoords,
         /**
          * Gets the keypoints for a given object
          * @memberof core.position

--- a/src/utils/geo-cuboid.js
+++ b/src/utils/geo-cuboid.js
@@ -13,17 +13,10 @@ const geoCuboid = ({ lib, swLib }) => {
         measureCenter
     } = lib.measurements;
 
-    const getCuboidCoords = (cuboidGeom) => {
-        const bBox = measureBoundingBox(cuboidGeom);
+    const { position } = swLib.core
 
-        return {
-            right: bBox[1][0], // (+X)
-            left: bBox[0][0], // (-X)
-            back: bBox[1][1], // (+Y)
-            front: bBox[0][1], // (-Y)
-            top: bBox[1][2], // (+Z)
-            bottom: bBox[0][2], // (-Z)
-        }
+    const getCuboidCoords = (cuboidGeom) => {
+        return position.getGeomCoords(cuboidGeom)
     }
 
     const getCuboidCorners = (cuboidGeom) => {

--- a/src/utils/geo-rectangle.js
+++ b/src/utils/geo-rectangle.js
@@ -13,15 +13,10 @@ const geoRectangle = ({ lib, swLib }) => {
         measureCenter
     } = lib.measurements;
 
-    const getRectangleCoords = (rectGeom) => {
-        const bBox = measureBoundingBox(rectGeom);
+    const { position } = swLib.core
 
-        return {
-            right: bBox[1][0], // (+X)
-            left: bBox[0][0], // (-X)
-            back: bBox[1][1], // (+Y)
-            front: bBox[0][1], // (-Y)
-        }
+    const getRectangleCoords = (rectGeom) => {
+        return position.getGeomCoords(rectGeom)
     }
 
     const getRectangleCorners = (rectGeom) => {

--- a/src/utils/geo-triangle.js
+++ b/src/utils/geo-triangle.js
@@ -41,6 +41,52 @@ const geoTriangle = ({ lib, swLib }) => {
         return null;
     }
 
+    const solve30DegRtTriangle = ({
+        hypot,
+        long,
+        short,
+    }) => {
+        const invalidHypot = typeof hypot != 'number' || hypot < 0
+        const invalidShort = typeof short != 'number' || short < 0
+        const invalidLong = typeof long != 'number' || long < 0
+
+        if (invalidHypot && invalidShort && invalidLong) {
+            // we need at least one valid value
+            return null;
+        }
+
+        const sides = [hypot, long, short];
+        const firstValidIdx = sides.findIndex(sideVal => !!sideVal)
+
+        let outHypot = 0;
+        let outLong = 0;
+        let outShort = 0;
+
+        switch (firstValidIdx) {
+            case 0:
+                outHypot = hypot;
+                outLong = hypot / 2 * Math.sqrt(3);
+                outShort = hypot / 2;
+                break;
+            case 1:
+                outHypot = long / Math.sqrt(3) * 2;
+                outLong = long;
+                outShort = long / Math.sqrt(3);
+                break;
+            case 2:
+                outHypot = short * 2;
+                outLong = short * Math.sqrt(3);
+                outShort = short;
+                break;
+        }
+
+        return {
+            hypot: outHypot,
+            long: outLong,
+            short: outShort,
+        }
+    }
+
     return {
         getTriangleCtrlPoints,
         centroid,

--- a/src/utils/geo-triangle.js
+++ b/src/utils/geo-triangle.js
@@ -96,6 +96,7 @@ const geoTriangle = ({ lib, swLib }) => {
         incentre,
         incircleRadius,
         eulerLine,
+        solve30DegRtTriangle,
     }
 }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -7,7 +7,7 @@
 
 const init = ({ lib, swLib }) => {
     const utils = {
-        transform: require('./transform').init({ lib }),
+        transform: require('./transform').init({ lib, swLib }),
     }
 
     // Dependent on lib and core modules

--- a/src/utils/super-primitives.js
+++ b/src/utils/super-primitives.js
@@ -273,13 +273,13 @@ const superPrimitivesInit = ({ lib, swLib }) => {
         // [x,y,z (default)]
         const mPanelSpecs = [
             {
-                size: [size[2], size[1], specs.meshPanelThickness],
-                rotation: [0, Math.PI / 2, 0],
+                size: [size[1], size[2], specs.meshPanelThickness],
+                rotation: [TAU / 4, 0, TAU / 4],
                 scaleFactors: [size[0] / specs.meshPanelThickness * 3, 1, 1],
             },
             {
                 size: [size[0], size[2], specs.meshPanelThickness],
-                rotation: [Math.PI / 2, 0, 0],
+                rotation: [TAU / 4, 0, 0],
                 scaleFactors: [1, size[1] / specs.meshPanelThickness * 3, 1],
             },
             {

--- a/src/utils/super-primitives.js
+++ b/src/utils/super-primitives.js
@@ -237,52 +237,56 @@ const superPrimitivesInit = ({ lib, swLib }) => {
             }
         });
 
-        let mainShape = align({ modes: ['center', 'center', 'center'] }, union(...parts))
+        // let mainShape = align({ modes: ['center', 'center', 'center'] }, union(...parts))
+        let mainShape = union(...parts)
 
         const hasInset = edgeInsets.some(insetVal => insetVal > 0)
+        console.log(`hasInset: ${hasInset}`)
         const hasOffset = edgeOffsets.some(offsetVal => offsetVal > 0)
+        console.log(`hasOffset: ${hasOffset}`)
 
         if (hasInset) {
             edgeInsets.forEach((insetWidth, idx) => {
+                console.log(insetWidth, idx)
                 if (insetWidth === 0) {
                     return
                 }
                 const isTop = idx === 0;
-                let sectionAlignOpts = {}
-                let flangeAlignOpts = {}
+                let insetSectionAlignOpts = {};
+                let insetFlangeAlignOpts = {};
                 const flipOpts = []
                 if (isTop) {
-                    sectionAlignOpts = { modes: ['min', 'min', 'max'], relativeTo: [0, 0, size[2]], }
-                    flangeAlignOpts = { modes: ['center', 'center', 'max'], relativeTo: [0, 0, size[2]], }
+                    insetSectionAlignOpts = { modes: ['min', 'min', 'max'] }
+                    insetFlangeAlignOpts = { modes: ['center', 'center', 'max'], relativeTo: [0, 0, baseCuboidCoords.top], }
                     flipOpts.push('vertical')
                 } else {
-                    sectionAlignOpts = { modes: ['min', 'min', 'min'], relativeTo: [0, 0, 0], }
-                    flangeAlignOpts = { modes: ['center', 'center', 'min'], relativeTo: [0, 0, 0], }
+                    insetSectionAlignOpts = { modes: ['min', 'min', 'min'] };
+                    insetFlangeAlignOpts = { modes: ['center', 'center', 'min'], relativeTo: [0, 0, baseCuboidCoords.bottom], };
                 }
                 const insetSection = align(
-                    sectionAlignOpts,
+                    insetSectionAlignOpts,
                     edgeFlangeProfile('inset', insetWidth, 0.5, flipOpts)
                 )
                 const insetFlanges = [
                     align(
-                        { modes: ['min', 'center', 'center'], relativeTo: [baseCuboidCoords.right, 0, 0] },
-                        rotate([TAU / 4, 0, TAU / 2], extrudeLinear({ height: 10 }, insetSection))
-                    ),
-                    align(
-                        { modes: ['center', 'min', 'center'], relativeTo: [0, baseCuboidCoords.back, 0] },
-                        rotate([TAU / 4, 0, TAU * 0.75], extrudeLinear({ height: 10 }, insetSection))
-                    ),
-                    align(
-                        { modes: ['max', 'center', 'center'], relativeTo: [baseCuboidCoords.left, 0, 0] },
+                        { modes: ['max', 'center', 'center'], relativeTo: [baseCuboidCoords.right - specs.meshPanelThickness, 0, 0] },
                         rotate([TAU / 4, 0, 0], extrudeLinear({ height: 10 }, insetSection))
                     ),
                     align(
-                        { modes: ['center', 'max', 'center'], relativeTo: [0, baseCuboidCoords.front, 0] },
+                        { modes: ['center', 'max', 'center'], relativeTo: [0, baseCuboidCoords.back - specs.meshPanelThickness, 0] },
                         rotate([TAU / 4, 0, TAU / 4], extrudeLinear({ height: 10 }, insetSection))
+                    ),
+                    align(
+                        { modes: ['min', 'center', 'center'], relativeTo: [baseCuboidCoords.left + specs.meshPanelThickness, 0, 0] },
+                        rotate([TAU / 4, 0, TAU / 2], extrudeLinear({ height: 10 }, insetSection))
+                    ),
+                    align(
+                        { modes: ['center', 'min', 'center'], relativeTo: [0, baseCuboidCoords.front + specs.meshPanelThickness, 0] },
+                        rotate([TAU / 4, 0, TAU * 0.75], extrudeLinear({ height: 10 }, insetSection))
                     ),
                 ]
                 const insetReinforcement = align(
-                    flangeAlignOpts,
+                    insetFlangeAlignOpts,
                     union(...insetFlanges)
                 )
 
@@ -292,45 +296,46 @@ const superPrimitivesInit = ({ lib, swLib }) => {
 
         if (hasOffset) {
             edgeOffsets.forEach((offsetWidth, idx) => {
+                console.log(offsetWidth, idx)
                 if (offsetWidth === 0) {
                     return
                 }
                 const isTop = idx === 0;
-                let sectionAlignOpts = {};
-                let flangeAlignOpts = {};
+                let offsetSectionAlignOpts = {};
+                let offsetFlangeAlignOpts = {};
                 const flipOpts = []
                 if (isTop) {
-                    sectionAlignOpts = { modes: ['min', 'min', 'max'], relativeTo: [0, 0, size[2]], }
-                    flangeAlignOpts = { modes: ['center', 'center', 'max'], relativeTo: [0, 0, size[2]], }
+                    offsetSectionAlignOpts = { modes: ['min', 'min', 'max'] }
+                    offsetFlangeAlignOpts = { modes: ['center', 'center', 'max'], relativeTo: [0, 0, baseCuboidCoords.top], }
                     flipOpts.push('vertical')
                 } else {
-                    sectionAlignOpts = { modes: ['min', 'min', 'min'], relativeTo: [0, 0, 0], };
-                    flangeAlignOpts = { modes: ['center', 'center', 'min'], relativeTo: [0, 0, 0], };
+                    offsetSectionAlignOpts = { modes: ['min', 'min', 'min'] };
+                    offsetFlangeAlignOpts = { modes: ['center', 'center', 'min'], relativeTo: [0, 0, baseCuboidCoords.bottom], };
                 }
                 const offsetSection = align(
-                    sectionAlignOpts,
+                    offsetSectionAlignOpts,
                     edgeFlangeProfile('offset', offsetWidth, 0.5, flipOpts)
                 )
                 const offsetFlanges = [
                     align(
-                        { modes: ['max', 'center', 'center'], relativeTo: [baseCuboidCoords.right, 0, 0] },
-                        rotate([TAU / 4, 0, TAU / 2], extrudeLinear({ height: 10 }, offsetSection))
-                    ),
-                    align(
-                        { modes: ['center', 'max', 'center'], relativeTo: [0, baseCuboidCoords.back, 0] },
-                        rotate([TAU / 4, 0, TAU * 0.75], extrudeLinear({ height: 10 }, offsetSection))
-                    ),
-                    align(
-                        { modes: ['min', 'center', 'center'], relativeTo: [baseCuboidCoords.left, 0, 0] },
+                        { modes: ['min', 'center', 'center'], relativeTo: [baseCuboidCoords.right, 0, 0] },
                         rotate([TAU / 4, 0, 0], extrudeLinear({ height: 10 }, offsetSection))
                     ),
                     align(
-                        { modes: ['center', 'min', 'center'], relativeTo: [0, baseCuboidCoords.front, 0] },
+                        { modes: ['center', 'min', 'center'], relativeTo: [0, baseCuboidCoords.back, 0] },
                         rotate([TAU / 4, 0, TAU / 4], extrudeLinear({ height: 10 }, offsetSection))
+                    ),
+                    align(
+                        { modes: ['max', 'center', 'center'], relativeTo: [baseCuboidCoords.left, 0, 0] },
+                        rotate([TAU / 4, 0, TAU / 2], extrudeLinear({ height: 10 }, offsetSection))
+                    ),
+                    align(
+                        { modes: ['center', 'max', 'center'], relativeTo: [0, baseCuboidCoords.front, 0] },
+                        rotate([TAU / 4, 0, TAU * 0.75], extrudeLinear({ height: 10 }, offsetSection))
                     ),
                 ]
                 const offsetReinforcement = align(
-                    flangeAlignOpts,
+                    offsetFlangeAlignOpts,
                     union(...offsetFlanges)
                 )
 

--- a/src/utils/super-primitives.js
+++ b/src/utils/super-primitives.js
@@ -310,25 +310,22 @@ const superPrimitivesInit = ({ lib, swLib }) => {
                     return
                 }
                 const isTop = idx === 0;
-                // const insetHeight = geometry.triangle.solve30DegRtTriangle({ short: insetWidth }).long;
-                // const sectionAlignOpts = isTop
-                //     ? { modes: ['min', 'min', 'max'], relativeTo: [0, 0, height], }
-                //     : { modes: ['min', 'min', 'min'], relativeTo: [0, 0, 0], };
-                // const ringAlignOpts = isTop
-                //     ? { modes: ['center', 'center', 'max'], relativeTo: [0, 0, height], }
-                //     : { modes: ['center', 'center', 'min'], relativeTo: [0, 0, 0], };
-
-                // const triangleSection = triangle({ type: 'SAS', values: [insetWidth, TAU / 4, insetHeight] })
-                // const insetSection = align(
-                //     sectionAlignOpts,
-                //     isTop ? mirror({ normal: [0, 1, 0] }, triangleSection) : triangleSection,
-                // );
+                let sectionAlignOpts = {}
+                let ringAlignOpts = {}
                 const flipOpts = []
-                if (!isTop) {
+                if (isTop) {
+                    sectionAlignOpts = { modes: ['min', 'min', 'max'], relativeTo: [0, 0, height], }
+                    ringAlignOpts = { modes: ['center', 'center', 'max'], relativeTo: [0, 0, height], }
                     flipOpts.push('vertical')
+                } else {
+                    sectionAlignOpts = { modes: ['min', 'min', 'min'], relativeTo: [0, 0, 0], }
+                    ringAlignOpts = { modes: ['center', 'center', 'min'], relativeTo: [0, 0, 0], }
                 }
-                const insetSection = edgeFlangeProfile('inset', insetWidth, 0.5, flipOpts)
-                let insetRing = align(
+                const insetSection = align(
+                    sectionAlignOpts,
+                    edgeFlangeProfile('inset', insetWidth, 0.5, flipOpts)
+                )
+                const insetRing = align(
                     ringAlignOpts,
                     extrudeRotate({ segments }, translate([radius - thickness - insetWidth, 0, 0], insetSection))
                 );
@@ -344,25 +341,22 @@ const superPrimitivesInit = ({ lib, swLib }) => {
                     return
                 }
                 const isTop = idx === 0;
-                // const offsetHeight = geometry.triangle.solve30DegRtTriangle({ short: insetWidth }).long;
-                // const sectionAlignOpts = isTop
-                //     ? { modes: ['min', 'min', 'max'], relativeTo: [0, 0, height], }
-                //     : { modes: ['min', 'min', 'min'], relativeTo: [0, 0, 0], };
-                // const ringAlignOpts = isTop
-                //     ? { modes: ['center', 'center', 'max'], relativeTo: [0, 0, height], }
-                //     : { modes: ['center', 'center', 'min'], relativeTo: [0, 0, 0], };
-
-                // const triangleSection = mirror({ normal: [1, 0, 0] }, triangle({ type: 'SAS', values: [offsetWidth, TAU / 4, offsetHeight] }));
-                // const offsetSection = align(
-                //     sectionAlignOpts,
-                //     isTop ? mirror({ normal: [0, 1, 0] }, triangleSection) : triangleSection,
-                // );
+                let sectionAlignOpts = {};
+                let ringAlignOpts = {};
                 const flipOpts = []
-                if (!isTop) {
+                if (isTop) {
+                    sectionAlignOpts = { modes: ['min', 'min', 'max'], relativeTo: [0, 0, height], }
+                    ringAlignOpts = { modes: ['center', 'center', 'max'], relativeTo: [0, 0, height], }
                     flipOpts.push('vertical')
+                } else {
+                    sectionAlignOpts = { modes: ['min', 'min', 'min'], relativeTo: [0, 0, 0], };
+                    ringAlignOpts = { modes: ['center', 'center', 'min'], relativeTo: [0, 0, 0], };
                 }
-                const offsetSection = edgeFlangeProfile('offset', offsetWidth, 0.5, flipOpts)
-                let offsetRing = align(
+                const offsetSection = align(
+                    sectionAlignOpts,
+                    edgeFlangeProfile('offset', offsetWidth, 0.5, flipOpts)
+                )
+                const offsetRing = align(
                     ringAlignOpts,
                     extrudeRotate({ segments }, translate([radius, 0, 0], offsetSection))
                 );

--- a/src/utils/super-primitives.js
+++ b/src/utils/super-primitives.js
@@ -279,7 +279,7 @@ const superPrimitivesInit = ({ lib, swLib }) => {
             },
             {
                 size: [size[0], size[2], specs.meshPanelThickness],
-                rotation: [TAU / 4, 0, 0],
+                rotation: [TAU / -4, 0, 0],
                 scaleFactors: [1, size[1] / specs.meshPanelThickness * 3, 1],
             },
             {
@@ -301,13 +301,24 @@ const superPrimitivesInit = ({ lib, swLib }) => {
                 edgeOffsets
             }));
 
+            let flipNormal = [0, 0, 0]
+            if (idx === 0) {
+                flipNormal = [1, 0, 0]
+            } else if (idx === 1) {
+                flipNormal = [0, 1, 0]
+            } else {
+                flipNormal = [0, 0, 1]
+            }
+
+            const flippedPanel = mirror({ normal: flipNormal }, rotatedPanel)
+
             const skipBottom = openBottom && idx == 2;
             if (!skipBottom) {
                 parts.push(align({ modes: ['min', 'min', 'min'], relativeTo: baseCuboidBb[0] }, rotatedPanel))
             }
             const skipTop = openTop && idx == 2;
             if (!skipTop) {
-                parts.push(align({ modes: ['max', 'max', 'max'], relativeTo: baseCuboidBb[1] }, rotatedPanel))
+                parts.push(align({ modes: ['max', 'max', 'max'], relativeTo: baseCuboidBb[1] }, flippedPanel))
             }
         });
 

--- a/src/utils/super-primitives.js
+++ b/src/utils/super-primitives.js
@@ -249,7 +249,7 @@ const superPrimitivesInit = ({ lib, swLib }) => {
                     return
                 }
                 const isTop = idx === 0;
-                const insetHeight = insetWidth * Math.sqrt(3);
+                const insetHeight = geometry.triangle.solve30DegRtTriangle({ short: insetWidth }).long;
                 const sectionAlignOpts = isTop
                     ? { modes: ['min', 'min', 'max'], relativeTo: [0, 0, height], }
                     : { modes: ['min', 'min', 'min'], relativeTo: [0, 0, 0], };
@@ -278,7 +278,7 @@ const superPrimitivesInit = ({ lib, swLib }) => {
                     return
                 }
                 const isTop = idx === 0;
-                const offsetHeight = offsetWidth * Math.sqrt(3);
+                const offsetHeight = geometry.triangle.solve30DegRtTriangle({ short: insetWidth }).long;
                 const sectionAlignOpts = isTop
                     ? { modes: ['min', 'min', 'max'], relativeTo: [0, 0, height], }
                     : { modes: ['min', 'min', 'min'], relativeTo: [0, 0, 0], };

--- a/src/utils/transform.js
+++ b/src/utils/transform.js
@@ -5,12 +5,28 @@
  * @namespace utils.transform
  */
 
-const transformUtils = ({ lib }) => {
+const transformUtils = ({ lib, swLib }) => {
     const { subtract } = lib.booleans
     const { measureDimensions } = lib.measurements;
     const { cuboid } = lib.primitives
     const { align, mirror, rotate } = lib.transforms
     const { colorize } = lib.colors
+
+    /**
+     * ...
+     * @param {object} opts 
+     * @param {boolean} opts.reverse 
+     * @param {object[]} geoms 
+     */
+    const stack = ({ reverse = false }, geoms) => {
+        let stackHeight = 0
+        const geomList = reverse ? geoms.reverse() : geoms
+        return geomList.map(geom => {
+            const alignedGeom = align({ modes: ['center', 'center', 'min'], relativeTo: [0, 0, stackHeight] }, geom)
+            stackHeight = stackHeight + measureDimensions(geom)[2]
+            return alignedGeom
+        })
+    }
 
     return {
         /**
@@ -87,7 +103,8 @@ const transformUtils = ({ lib }) => {
             cutAssembly = subtract(cutAssembly, cutBox2);
 
             return cutAssembly
-        }
+        },
+        stack
     }
 }
 


### PR DESCRIPTION
### New features

- transform.stack() — Stacks a set of geometries
    - opts.reverse (default `false`) — Starts the stack with the last element instead of the first
- super-primitives
    -  meshPanel() — edge insets & offsets turn this into a decent flanged joist

### Maintenance

- super-primitives
    - meshCuboid() — edge insets & offsets, option for open bottom